### PR TITLE
Add optional parameter to reduce client memory usage instead of the WithoutBeaconState option in Validators request

### DIFF
--- a/api/validatorsopts.go
+++ b/api/validatorsopts.go
@@ -26,6 +26,4 @@ type ValidatorsOpts struct {
 	Indices []phase0.ValidatorIndex
 	// PubKeys is a list of validator public keys to restrict the returned values.  If no public keys are supplied then no filter will be applied.
 	PubKeys []phase0.BLSPubKey
-	// WithoutBeaconState prevents the retrieval of BeaconState for large validator sets, which is often much faster but allocates much more memory.
-	WithoutBeaconState bool
 }

--- a/http/parameters.go
+++ b/http/parameters.go
@@ -30,6 +30,7 @@ type parameters struct {
 	pubKeyChunkSize int
 	extraHeaders    map[string]string
 	enforceJSON     bool
+	reduceMemUsage  bool
 }
 
 // Parameter is the interface for service parameters.
@@ -96,6 +97,14 @@ func WithExtraHeaders(headers map[string]string) Parameter {
 func WithEnforceJSON(enforceJSON bool) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.enforceJSON = enforceJSON
+	})
+}
+
+// WithReducedMemoryUsage reduces memory usage by disabling certain actions that may take significant amount of memory.
+// Enabling this may result in longer response times.
+func WithReducedMemoryUsage(reduceMemUsage bool) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.reduceMemUsage = reduceMemUsage
 	})
 }
 

--- a/http/service.go
+++ b/http/service.go
@@ -63,6 +63,7 @@ type Service struct {
 	// Endpoint support.
 	enforceJSON              bool
 	connectedToDVTMiddleware bool
+	reduceMemUsage           bool
 }
 
 // New creates a new Ethereum 2 client service, connecting with a standard HTTP.
@@ -120,6 +121,7 @@ func New(ctx context.Context, params ...Parameter) (eth2client.Service, error) {
 		userPubKeyChunkSize: parameters.pubKeyChunkSize,
 		extraHeaders:        parameters.extraHeaders,
 		enforceJSON:         parameters.enforceJSON,
+		reduceMemUsage:      parameters.reduceMemUsage,
 	}
 
 	// Fetch static values to confirm the connection is good.

--- a/http/validators.go
+++ b/http/validators.go
@@ -128,7 +128,7 @@ func (s *Service) Validators(ctx context.Context,
 		return nil, errors.New("cannot specify both indices and public keys")
 	}
 
-	if !opts.WithoutBeaconState {
+	if !s.reduceMemUsage {
 		if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
 			// Request is for all validators; fetch from state.
 			return s.validatorsFromState(ctx, opts)


### PR DESCRIPTION
Implementation of https://github.com/attestantio/go-eth2-client/pull/105#issuecomment-1937767726